### PR TITLE
change version of org.asciidoctor.convert version 

### DIFF
--- a/src/example/groovy-dsl/build.gradle
+++ b/src/example/groovy-dsl/build.gradle
@@ -4,7 +4,7 @@ plugins {
 // end::plugins[]
     id 'com.gradle.build-scan' version '1.12.1'
 // tag::plugins[]
-    id 'org.asciidoctor.convert' version '1.5.6' apply false // <1>
+    id 'org.asciidoctor.convert' version '1.5.9' apply false // <1>
 }
 // end::plugins[]
 

--- a/src/example/kotlin-dsl/build.gradle.kts
+++ b/src/example/kotlin-dsl/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     // end::plugins[]
     `build-scan`
 // tag::plugins[]
-    id("org.asciidoctor.convert") version "1.5.6" apply false // <1>
+    id("org.asciidoctor.convert") version "1.5.9" apply false // <1>
 }
 // end::plugins[]
 


### PR DESCRIPTION
the 1.5.6 version of org.asciidoctor.convert  can not be download from repository,but the 1.5.9 is ok