### PR TITLE
Add missed marker/pointer in kotlin sample

### DIFF
--- a/src/example/kotlin-dsl/docs/build.gradle.kts
+++ b/src/example/kotlin-dsl/docs/build.gradle.kts
@@ -1,14 +1,14 @@
 import org.asciidoctor.gradle.AsciidoctorTask
 
 plugins {
-    id("org.asciidoctor.convert")       // <1>
+    id("org.asciidoctor.convert")               // <1>
 }
 
 tasks.asciidoctor {
     sources(delegateClosureOf<PatternSet> {
-        include("greeter.adoc")         // <2>
+        include("greeter.adoc")                 // <2>
     })
 }
 
-tasks.build { dependsOn(tasks.asciidoctor) }
+tasks.build { dependsOn(tasks.asciidoctor) }    // <3>
 


### PR DESCRIPTION
add comment for 3 point:
```
Adds asciidoctor task into the build lifecycle so that if build is executed for the top-level project, then documentation will be built as well.
```